### PR TITLE
簡易的なテーブル作成+ 座標取得

### DIFF
--- a/src/hooks/useCoordinate.ts
+++ b/src/hooks/useCoordinate.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+
+export const useCoordinate = () => {
+  const [coordinate, serCoordinate] = useState({ X: 30, Y: 30 });
+
+  // ドラッグし始めた(MouseDownした)時のマウス座標 MouseDown時に保存し、MouseUp時にnullを入れてリセット
+  const [mouseMoveCoordinate, setMouseMoveCoordinate] = useState<{
+    X: number;
+    Y: number;
+  } | null>(null);
+
+  useEffect(() => {
+    // ドラッグし始めたならMouseMoveをイベントリスナーに登録し、onMouseMoveでobjectを動かす用の座標を計算する
+    document.addEventListener("mousemove", onMouseMove);
+
+    // MouseUpしたらドラッグ開始座標をリセット かつ MouseMoveのイベントリスナーも解除
+    document.addEventListener("mouseup", () => {
+      setMouseMoveCoordinate(null);
+      document.removeEventListener("mousemove", onMouseMove);
+    });
+  }, [mouseMoveCoordinate]);
+
+  const onMouseMove = (e: MouseEvent) => {
+    // ドラッグ開始地点から現在のマウスまでの座標を計算し、最後にドラッグ終了した時のobjectが動いた座標に加算する
+    if (mouseMoveCoordinate) {
+      const afterCoordinate = {
+        X: e.clientX - mouseMoveCoordinate.X + coordinate.X,
+        Y: e.clientY - mouseMoveCoordinate.Y + coordinate.Y,
+      };
+      serCoordinate(afterCoordinate);
+    }
+  };
+
+  return {
+    data: {
+      // MouseDownでドラッグ開始時の座標を保存
+      onMouseDown: (e: React.MouseEvent) =>
+        setMouseMoveCoordinate({ X: e.clientX, Y: e.clientY }),
+
+      // MouseUp時にマウス位置をリセット
+      onMouseUp: () => setMouseMoveCoordinate(null),
+
+      // 座標のstyle
+      style: {
+        transform: `translate3d(${coordinate.X}px, ${coordinate.Y}px, 0)`,
+      },
+    },
+    // 使っていない
+    coordinate: coordinate
+  };
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,9 +3,11 @@ import ReactDOM from "react-dom";
 import { Routing } from "./router";
 import reportWebVitals from "./reportWebVitals";
 import { BrowserRouter } from "react-router-dom";
+import CssBaseline from '@mui/material/CssBaseline';
 
 ReactDOM.render(
   <React.StrictMode>
+    <CssBaseline />
     <BrowserRouter>
       <Routing />
     </BrowserRouter>

--- a/src/ui/components/Lv3/TodoForm.tsx
+++ b/src/ui/components/Lv3/TodoForm.tsx
@@ -38,7 +38,7 @@ export const TodoForm: React.FC<Props> = memo(({ todo, changeTodo }: Props) => {
 
   const onSubmit: SubmitHandler<{ title: string }> = useCallback((data) => {console.log(data)},[]);
 
-  console.log("test")
+  console.log("react hook formなしの時に表示される")
 
   return (
     <>
@@ -49,7 +49,7 @@ export const TodoForm: React.FC<Props> = memo(({ todo, changeTodo }: Props) => {
           render={({ field }) => (
             <TextField
               {...field}
-              label="テキストフィールド"
+              label="react hook formあり"
               error={errors.title ? true : false}
               helperText={errors.title?.message}
               fullWidth
@@ -58,9 +58,7 @@ export const TodoForm: React.FC<Props> = memo(({ todo, changeTodo }: Props) => {
             />
           )}
         />
-        <input onChange={(e) => setTest(e.target.value)}></input>
-        <br />
-        {test}
+        <input placeholder="react hook formなし" onChange={(e) => setTest(e.target.value)}></input>
         <br />
         <input type="submit" />
       </form>

--- a/src/ui/pages/index.tsx
+++ b/src/ui/pages/index.tsx
@@ -1,20 +1,136 @@
-import { memo, VFC } from "react";
-import { useTodo } from "../../hooks/todo"
-import { Todo } from "../../domain/todo"
-import { TodoForm } from "../components/Lv3/TodoForm"
+import { memo, useState, useEffect } from "react";
+import { useTodo } from "../../hooks/todo";
+import { TodoForm } from "../components/Lv3/TodoForm";
+import { Box } from "@mui/material";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import { SelectChangeEvent } from "@mui/material";
+import Grid from "@mui/material/Grid";
+import InputLabel from "@mui/material/InputLabel";
+import Button from "@mui/material/Button";
+import Radio from "@mui/material/Radio";
+
+import { useCoordinate } from "../../hooks/useCoordinate";
+
+// 方眼紙の背景のCSS
+const styles = {
+  backgroundImage:
+    "linear-gradient(0deg, transparent calc(100% - 1px), #f0f0f0 calc(100% - 1px)) , linear-gradient(90deg, transparent calc(100% - 1px), #f0f0f0 calc(100% - 1px))",
+  backgroundSize: "30px 30px",
+  backgroundRepeat: "repeat",
+  backgroundPosition: "left top",
+  width: "1000px",
+  height: "500px",
+};
 
 export const TopPage: React.FC = memo(() => {
-  const { loading, todo, changeTodo } = useTodo()
+  const { loading, todo, changeTodo } = useTodo();
+  const [wSquare, setWSquare] = useState<number>(0);
+  const [hSquare, setHSquare] = useState<number>(0);
+  // const [coordinate, serCoordinate] = useState({ X: 0, Y: 0 });
+  const [isDisable, setDisable] = useState<boolean>(false);
+
+  const mouseEvent = useCoordinate();
+
+  const handleChange = (e: SelectChangeEvent<number>) => {
+    switch (e.target.name) {
+      case "w_square":
+        return setWSquare(Number(e.target.value));
+      case "h_square":
+        return setHSquare(Number(e.target.value));
+    }
+  };
+
+  // useEffect(() => {
+  //   serCoordinate(mouseEvent.coordinate)
+  // }, [mouseEvent]);
+
+
+  const tableCreate = async (e: React.FormEvent) => {
+    setDisable(true);
+  };
 
   if (loading) {
-    return <div>{"ローディング中"}</div>
+    return <div>{"ローディング中"}</div>;
   }
-  
+
   return (
     <>
-      <h1>TOP</h1>
-      <TodoForm todo={todo} changeTodo={changeTodo} />
+      <Box sx={styles}>
+        {isDisable && (
+          <div {...mouseEvent.data}>
+            <div
+              style={{
+                height: 30 * hSquare,
+                width: 30 * wSquare,
+                background: "#a3c6f9",
+                position: "absolute",
+                zIndex: 1300,
+                boxSizing: "border-box",
+              }}
+            >
+              <Radio
+                sx={{ width: "30px", height: "30px", zIndex: 1300 }}
+                size="small"
+              />
+              <Radio
+                sx={{ width: "30px", height: "30px", zIndex: 1300 }}
+                size="small"
+              />
+              <Radio
+                sx={{ width: "30px", height: "30px", zIndex: 1300 }}
+                size="small"
+              />
+              <Radio
+                sx={{ width: "30px", height: "30px", zIndex: 1300 }}
+                size="small"
+              />
+            </div>
+          </div>
+        )}
+      </Box>
+      <Grid item container sm={12} xs={12}>
+        <Grid item sm={1} xs={12}>
+          <InputLabel>横</InputLabel>
+        </Grid>
+        <Grid item sm={3} xs={12}>
+          <Select
+            name="w_square"
+            value={wSquare}
+            variant="outlined"
+            onChange={handleChange}
+            defaultValue={wSquare}
+          >
+            <MenuItem value={1}>1</MenuItem>
+            <MenuItem value={2}>2</MenuItem>
+            <MenuItem value={3}>3</MenuItem>
+          </Select>
+        </Grid>
+      </Grid>
+      <Grid item container sm={12} xs={12}>
+        <Grid item sm={1} xs={12}>
+          <InputLabel>縦</InputLabel>
+        </Grid>
+        <Grid item sm={3} xs={12}>
+          <Select
+            name="h_square"
+            value={hSquare}
+            variant="outlined"
+            onChange={handleChange}
+            defaultValue={hSquare}
+          >
+            <MenuItem value={1}>1</MenuItem>
+            <MenuItem value={2}>2</MenuItem>
+            <MenuItem value={3}>3</MenuItem>
+          </Select>
+        </Grid>
+      </Grid>
+      <Button variant="contained" onClick={tableCreate}>
+        テーブル作成
+      </Button>
       <br />
+      <p style={{ paddingTop: "30px" }}>--↓react hook formの練習--</p>
+      <TodoForm todo={todo} changeTodo={changeTodo} />
     </>
   );
 });


### PR DESCRIPTION
# 概要

簡易的なテーブルの作成し、ドラッグ＆ドロップをして座標軸を取得できるようにする

# やったこと

- 方眼紙のような背景作成
- マス目の大きさ分のテーブルを作成できるようにする
- ドラックアンドドロップで座標軸を取得してstateで管理する
- 作成したマス分の座席を設定できる